### PR TITLE
feat: add support for default theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ By default svelte-themer persists the chosen theme with `localStorage`, and can 
 
 `ThemeWrapper` will load a theme on first visit based on the following order:
 
+1. User-provided - The value specified in the `theme` prop.
 1. Saved - User's stored choice (from `localStorage`)
-2. Prefers - User's Operating System settings (via `prefers-color-scheme`)
-3. Fallback - First theme in `themes` specified (from presets, `light`)
+1. Prefers - User's Operating System settings (via `prefers-color-scheme`)
+1. Fallback - First theme in `themes` specified (from presets, `light`)
 
 By default, the "prefers" step will choose a theme based on OS settings, however this can be modified to directly choose "light" or "dark" by leveraging the `mode` prop:
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ By default svelte-themer persists the chosen theme with `localStorage`, and can 
 `ThemeWrapper` will load a theme on first visit based on the following order:
 
 1. User-provided - The value specified in the `theme` prop.
-1. Saved - User's stored choice (from `localStorage`)
-1. Prefers - User's Operating System settings (via `prefers-color-scheme`)
-1. Fallback - First theme in `themes` specified (from presets, `light`)
+2. Saved - User's stored choice (from `localStorage`)
+3. Prefers - User's Operating System settings (via `prefers-color-scheme`)
+4. Fallback - First theme in `themes` specified (from presets, `light`)
 
 By default, the "prefers" step will choose a theme based on OS settings, however this can be modified to directly choose "light" or "dark" by leveraging the `mode` prop:
 

--- a/components/ThemeWrapper.svelte
+++ b/components/ThemeWrapper.svelte
@@ -30,6 +30,11 @@
    */
   export let themes = presets
   /**
+   * Sets the specified theme as active
+   * @type {string | null} [theme='dark']
+   */
+  export let theme = null;
+  /**
    * Specify custom CSS variable prefix
    * @type {string | null} [prefix='theme']
    */
@@ -74,7 +79,10 @@
 
     // loading order: saved, prefers, fallback
     const saved = key ? localStorage?.getItem(key) : null
-    if (saved && themes[saved]) {
+
+    if (theme && themes[theme]) {
+      currentThemeName.set(theme)
+    } else  if (saved && themes[saved]) {
       currentThemeName.set(saved)
     } else {
       if (mode === 'auto' && preferredMode) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-themer",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "homepage": "https://svelte-themer.now.sh",
   "license": "MIT",
   "repository": {

--- a/types/components/ThemeWrapper.d.ts
+++ b/types/components/ThemeWrapper.d.ts
@@ -13,6 +13,12 @@ export interface ThemeWrapperProps {
   themes?: Object;
 
   /**
+   * Sets the specified theme as active
+   * @default null
+   */
+  theme?: string | null;
+
+  /**
    * Specify custom CSS variable prefix
    */
   prefix?: string | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,11 +2013,6 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-changesets@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/changesets/-/changesets-1.0.2.tgz#d4eb67f826c6b5e19b56ced4f5add72e1e0cadb8"
-  integrity sha1-1Otn+CbGteGbVs7U9a3XLh4Mrbg=
-
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
Adds support for user-provided theme selection on load. This is useful when dealing with multiple themes.

```js
const themes = {
  light: { ... },
  dark: { ... },
  hello: { ... },
  world: { ...}
}
```

```html
<ThemeWrapper themes="{themes}" theme="world">
```