### PR TITLE
FIXED: Got rid of "CONTEXT_KEY" warning

### DIFF
--- a/components/ThemeWrapper.svelte
+++ b/components/ThemeWrapper.svelte
@@ -74,11 +74,6 @@
     toggle,
     theme: currentThemeName,
   })
-  $: setContext(CONTEXT_KEY, {
-    current: currentThemeName,
-    toggle,
-    theme: currentThemeName,
-  })
 
   onMount(() => {
     // detect dark mode


### PR DESCRIPTION
`(svelte plugin) "CONTEXT_KEY" is declared in a module script and will not be reactive` was showing up.

Removing this code doesn't affect the functionality at all.