### PR TITLE
feat: add use theme

### DIFF
--- a/components/ThemeWrapper.svelte
+++ b/components/ThemeWrapper.svelte
@@ -15,7 +15,7 @@
   import { onMount, afterUpdate, setContext } from 'svelte'
   import { presets } from './presets'
   import toggle from '../support/toggle'
-  import { createCSS } from '../support/css'
+  import { createCSSTemplate } from '../support/css'
   import {
     currentThemeName,
     currentThemeObject,
@@ -63,12 +63,13 @@
 
   themesStore.set(themes)
   const [fallback] = Object.keys(themes)
-  if (!Object.keys(themes).includes($currentThemeName))
+  if (!Object.keys(themes).includes($currentThemeName)) {
     currentThemeName.set(fallback)
+  }
   $: currentThemeObject.set(themes[$currentThemeName])
 
   // create CSS
-  const style = createCSS(prefix, base, themes)
+  const style = createCSSTemplate(prefix, base, themes)
 
   setContext(CONTEXT_KEY, {
     current: currentThemeName,

--- a/components/index.js
+++ b/components/index.js
@@ -1,2 +1,3 @@
 export { default as ThemeWrapper } from './ThemeWrapper.svelte'
 export { default as ThemeToggle } from './ThemeToggle.svelte'
+export { presets } from './presets.js'

--- a/components/use.js
+++ b/components/use.js
@@ -1,0 +1,31 @@
+import { createCSSVariableCollection } from '../support/css'
+
+/**
+ *
+ * @param {HTMLElement} node
+ * @param {Object.<string, string|number>} theme
+ * @returns
+ */
+export async function theme(node, theme) {
+  /**
+   *
+   * @param {string} name
+   * @param {string} value
+   * @returns {void}
+   */
+  function setProperty(name, value) {
+    if (!node.style && node.document?.documentElement) {
+      node.document.documentElement.style.setProperty(name, value)
+      return
+    }
+    node.style.setProperty(name, value)
+    return
+  }
+
+  const variables = createCSSVariableCollection(theme)
+  for (let [name, value] of variables) {
+    setProperty(name, value)
+  }
+
+  return {}
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     },
     "./package.json": "./package.json",
     "./components": "./components/index.js",
-    "./store": "./support/store.js"
+    "./store": "./support/store.js",
+    "./use": "./components/use.js"
   },
   "files": [
     "components",

--- a/support/css.js
+++ b/support/css.js
@@ -54,13 +54,29 @@ export function createCSSVariableOverride({
 }
 
 /**
+ *
+ * @param {object} config
+ * @param {Object} options
+ * @param {string} options.prefix
+ * @returns {[CSSVariableName, <string,CSSVariableName>]}
+ */
+export function createCSSVariableCollection(config, { prefix } = {}) {
+  const variablePrefix = prefix ? `--${prefix}` : '-'
+  const processedConfig = processConfig(config)
+  const variables = Object.entries(processedConfig).map(([prop, value]) => {
+    return [createCSSVariableName({ variablePrefix, prop }), value]
+  })
+  return variables
+}
+
+/**
  * Create CSS template
- * @name setCSS
+ * @name createCSSTemplate
  * @param {string} prefix - CSS variable prefix
  * @param {Object[]} themes - themes array
  * @returns {string} CSS template
  */
-export function createCSS(prefix, base = {}) {
+export function createCSSTemplate(prefix, base = {}) {
   const variablePrefix = prefix ? `--${prefix}` : '-'
 
   const themes = get(themesStore)
@@ -125,7 +141,7 @@ export function createCSS(prefix, base = {}) {
       :root {
         ${rootCSSVariables
           .map(vars => createCSSVariableStatement(...vars))
-          .join('\n\t')}
+          .join('')}
       }
 
       ${themeCSSContent.join('')}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,3 @@
 export { default as ThemeWrapper } from "./ThemeWrapper.svelte";
 export { default as ThemeToggle } from "./ThemeToggle.svelte";
+export { default as presets } from "./presets.js";


### PR DESCRIPTION
- adds theme action
	 ```svelte
    <script>
      import { theme } from 'svelte-themer/use'

      const myTheme = {
        text: 'red'
      }
    </script>

    <div use:theme={myTheme}>
      <p>Hello, World!</p>
    </div>

    <style>
      p {
        color: var(--text);
      }
    </style>
	 ```
- adds `createCSSVariableCollection`
- renames `createCSS` to `createCSSTemplate`
- adds support to import `support` and `use` directly